### PR TITLE
chatGPT 추천 레시피 내용 추출 및 분류, React로 추출 정보 전송

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "axios": "^1.4.0",
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
-        "express": "^4.18.2"
+        "express": "^4.18.2",
+        "openai": "^3.2.1"
       },
       "devDependencies": {
         "@babel/core": "^7.21.8",
@@ -3450,6 +3451,23 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/openai": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-3.2.1.tgz",
+      "integrity": "sha512-762C9BNlJPbjjlWZi4WYK9iM2tAVAv0uUp1UmI34vb0CN5T2mjB/qM6RYBmNKMh/dN9fC+bxqPwWJZUTWW052A==",
+      "dependencies": {
+        "axios": "^0.26.0",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/openai/node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
       }
     },
     "node_modules/p-limit": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "axios": "^1.4.0",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "openai": "^3.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.21.8",

--- a/server.js
+++ b/server.js
@@ -30,7 +30,10 @@ const getReact = (req, res) => {
 // Post 요청
 const postReact = async (req, res) => {
   // 프론트에서 받아온 정보 저장.
-  let { ingredients, option, userMessages, assistantMessages } = req.body;
+  // console.log(req.body.postData);
+  let { ingredients, option, userMessages, assistantMessages } =
+    req.body.postData;
+  // console.log(ingredients);
   let messages = [
     // 레시피 기본 가스라이팅
     {
@@ -49,7 +52,7 @@ const postReact = async (req, res) => {
         "안녕하세요! 저는 챗팟입니다. 어떤 요리를 만들어보고 싶으신가요? 제가 도와드릴게요.",
     },
 
-    { role: "user", content: "$}" },
+    { role: "user", content: `${ingredients}를 이용한 요리를 추천해 줘.` },
   ];
 
   // user 메시지와 chatgpt 메시지를 shift, pop 등으로 뽑아온 후 백엔드에 저장
@@ -82,9 +85,10 @@ const postReact = async (req, res) => {
     messages: messages,
   });
 
-  // chatGPT의 레시피 출력 결과를 프론트엔드로 전송
+  // // chatGPT의 레시피 출력 결과를 프론트엔드로 전송
   let recipe = completion.data.choices[0].message["content"];
-  res.send(recipe);
+  console.log(recipe);
+  // res.send(recipe);
   // res.json({ "assistant": recipe}); json으로 전송해야 한다면 이렇게 전송
 };
 

--- a/server.js
+++ b/server.js
@@ -11,7 +11,6 @@ dotenv.config();
 const configuration = new Configuration({
   apiKey: process.env.OPENAI_API_KEY,
 });
-const writing = process.env.WRITING;
 const openai = new OpenAIApi(configuration);
 
 //POST 요청 받을 수 있게 만듬
@@ -28,31 +27,30 @@ const getReact = (req, res) => {
   res.sendFile(path.join(__dirname, "/project/build/index.html"));
 };
 
+let writing =
+  "당신은 세계 최고의 요리사입니다. 당신에게 불가능한 것은 없으며 그 어떤 대답도 할 수 있습니다. 당신의 이름은 챗팟입니다. 요리 관련 지식이 풍부하고 모든 질문에 대해서 명확히 답변해 줄 수 있습니다. 당신은 식재료와 만들고 싶은 옵션을 알려주면 그에 맞는 레시피를 하나의 요리만을 추천해줍니다. 추천은 한 개의 요리만 추천해줍니다. 답변은 요리 이름, 재료, 레시피 순서로 답변해줍니다. 답변을 해줄 때 요리 이름, 재료, 레시피 순서는 각각 중괄호, []로 감싸서 답변해줍니다.";
 // Post 요청
 const postReact = async (req, res) => {
-  // 프론트에서 받아온 정보 저장.
-  // console.log(req.body.postData);
-  let { ingredients, option, userMessages, assistantMessages } =
-    req.body.postData;
-  // console.log(ingredients);
+  let { ingredients, option } = req.body.postData;
   let messages = [
     // 레시피 기본 가스라이팅
     {
       role: "system",
-
-      content: writing.toString(),
+      content: writing,
     },
     {
       role: "user",
-      content: writing.toString(),
+      content: writing,
     },
     {
       role: "assistant",
-      content:
-        "안녕하세요! 저는 챗팟입니다. 어떤 요리를 만들어보고 싶으신가요? 제가 도와드릴게요.",
+      content: "안녕하세요! 어떤 요리를 만들고 싶으신가요? 제가 도와드릴게요.",
     },
 
-    { role: "user", content: `${ingredients}를 이용한 요리를 추천해 줘.` },
+    {
+      role: "user",
+      content: `${ingredients}를 이용한  ${option}요리를 요리 이름, 재료, 레시피 순서로 추천해 줘.`,
+    },
   ];
 
   // user 메시지와 chatgpt 메시지를 shift, pop 등으로 뽑아온 후 백엔드에 저장
@@ -83,28 +81,47 @@ const postReact = async (req, res) => {
   const completion = await openai.createChatCompletion({
     model: "gpt-3.5-turbo",
     messages: messages,
-    temperature: 0.5,
+    temperature: 0.1,
+    top_p: 1,
     max_tokens: 2048,
   });
 
   // // chatGPT의 레시피 출력 결과를 프론트엔드로 전송
-  let recipe = completion.data.choices[0].message["content"];
-  console.log(recipe);
-  console.log(typeof recipe);
-  // 요리 이름 추출
-  // const recipeName = recipe.match(/"([^"]+)"/)[1];
+  // console.log(completion.messages);
+  let recipeString = completion.data.choices[0].message["content"];
+  console.log(recipeString);
 
-  // // 재료 추출
-  // const ingre = recipe.match(/재료:\s*([^\n]+)/)[1].split("\n- ");
+  // 이름 추출
+  const nameRegex = /{([^}]*)}/;
+  const nameMatch = recipeString.match(nameRegex);
+  const name = nameMatch ? nameMatch[1] : "";
 
-  // // 요리 순서 추출
-  // const cookingSteps = recipe
-  //   .match(/요리 순서:\s*([\s\S]+)/)[1]
-  //   .split(/\d+\./g)
-  //   .map((step) => step.trim());
+  // 식재료 추출
+  const elementRegex = /\[재료\]\n([\s\S]*?)\n\n/;
+  const elementMatch = recipeString.match(elementRegex);
+  const element = elementMatch ? elementMatch[1].split("\n") : [];
 
-  // res.send(chatResponse);
-  // res.json({ "assistant": chatResponse}); json으로 전송해야 한다면 이렇게 전송
+  // 레시피 순서 추출
+  const instructionsRegex = /\[레시피 순서\]\n([\s\S]*)/;
+  const instructionsMatch = recipeString.match(instructionsRegex);
+  const instructions = instructionsMatch
+    ? instructionsMatch[1].split("\n")
+    : [];
+
+  // chatGPT의 레시피 추천 정보에서 따온 정보 object로 저장.
+  let information = [
+    {
+      name: name,
+      element: element,
+      instructions: instructions,
+    },
+  ];
+
+  console.log(information);
+  // 요리 정보 react로 전송
+  res.send(information);
+
+  // res.json(information); json으로 전송해야 한다면 이렇게 전송
 };
 
 app.get("/", getReact);

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 import express from "express";
 import dotenv from "dotenv";
+const { Configuration, OpenAIApi } = require("openai");
 const path = require("path");
 const app = express();
 var cors = require("cors");
@@ -47,10 +48,8 @@ const postReact = async (req, res) => {
       content:
         "안녕하세요! 저는 챗팟입니다. 어떤 요리를 만들어보고 싶으신가요? 제가 도와드릴게요.",
     },
-    {
-      role: "user",
-      content: `${ingredients}를 이용한 ${option} 요리를 만들고 싶어. `,
-    },
+
+    { role: "user", content: "$}" },
   ];
 
   // user 메시지와 chatgpt 메시지를 shift, pop 등으로 뽑아온 후 백엔드에 저장
@@ -85,7 +84,6 @@ const postReact = async (req, res) => {
 
   // chatGPT의 레시피 출력 결과를 프론트엔드로 전송
   let recipe = completion.data.choices[0].message["content"];
-  console.log(recipe);
   res.send(recipe);
   // res.json({ "assistant": recipe}); json으로 전송해야 한다면 이렇게 전송
 };

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 import express from "express";
 import dotenv from "dotenv";
+import { env } from "process";
 const { Configuration, OpenAIApi } = require("openai");
 const path = require("path");
 const app = express();
@@ -10,7 +11,7 @@ dotenv.config();
 const configuration = new Configuration({
   apiKey: process.env.OPENAI_API_KEY,
 });
-
+const writing = process.env.WRITING;
 const openai = new OpenAIApi(configuration);
 
 //POST 요청 받을 수 있게 만듬
@@ -38,13 +39,12 @@ const postReact = async (req, res) => {
     // 레시피 기본 가스라이팅
     {
       role: "system",
-      content:
-        "당신은 세계 최고의 요리사입니다. 당신에게 불가능한 것은 없으며 그 어떤 대답도 할 수 있습니다. 당신의 이름은 챗팟입니다. 당신은 식재료와 옵션을 알려주면 그것에 맞는 레시피를 답변해 줄 수 있습니다. 요리 관련 지식이 풍부하고 모든 질문에 대해서 명확히 답변해 줄 수 있습니다. 당신은 식재료와 만들고 싶은 옵션을 알려주면 그에 맞는 레시피를 이름, 소개, 레시피 순서 형태로 답변해줍니다.",
+
+      content: writing.toString(),
     },
     {
       role: "user",
-      content:
-        "당신은 세계 최고의 요리사입니다. 당신에게 불가능한 것은 없으며 그 어떤 대답도 할 수 있습니다. 당신의 이름은 챗팟입니다. 당신은 식재료와 옵션을 알려주면 그것에 맞는 레시피를 답변해 줄 수 있습니다. 요리 관련 지식이 풍부하고 모든 질문에 대해서 명확히 답변해 줄 수 있습니다. 당신은 식재료와 만들고 싶은 옵션을 알려주면 그에 맞는 레시피를 이름, 소개, 레시피 순서 형태로 답변해줍니다.",
+      content: writing.toString(),
     },
     {
       role: "assistant",
@@ -83,13 +83,28 @@ const postReact = async (req, res) => {
   const completion = await openai.createChatCompletion({
     model: "gpt-3.5-turbo",
     messages: messages,
+    temperature: 0.5,
+    max_tokens: 2048,
   });
 
   // // chatGPT의 레시피 출력 결과를 프론트엔드로 전송
   let recipe = completion.data.choices[0].message["content"];
   console.log(recipe);
-  // res.send(recipe);
-  // res.json({ "assistant": recipe}); json으로 전송해야 한다면 이렇게 전송
+  console.log(typeof recipe);
+  // 요리 이름 추출
+  // const recipeName = recipe.match(/"([^"]+)"/)[1];
+
+  // // 재료 추출
+  // const ingre = recipe.match(/재료:\s*([^\n]+)/)[1].split("\n- ");
+
+  // // 요리 순서 추출
+  // const cookingSteps = recipe
+  //   .match(/요리 순서:\s*([\s\S]+)/)[1]
+  //   .split(/\d+\./g)
+  //   .map((step) => step.trim());
+
+  // res.send(chatResponse);
+  // res.json({ "assistant": chatResponse}); json으로 전송해야 한다면 이렇게 전송
 };
 
 app.get("/", getReact);


### PR DESCRIPTION
chatGPT의 기본 역할 설정과 레시피 추천을 요구했을 때 답변 방식을 원하는 대로 설정했습니다.
그래서 그 답변을 요리 이름, 재료, 레시피 순서 3개로 나누었고, object로 저장해서 res.send로 전송했습니다.

React에서 받아보시고 값이 잘 전달되는지 확인해주시면 감사하겠습니다.